### PR TITLE
feat: 유저 보유 재료 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/controller/IngredientController.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/controller/IngredientController.java
@@ -1,0 +1,30 @@
+package com.ohgiraffers.refrigegobackend.ingredients.controller;
+
+import com.ohgiraffers.refrigegobackend.ingredients.dto.IngredientResponseDto;
+import com.ohgiraffers.refrigegobackend.ingredients.service.IngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 기준 재료 관련 API 컨트롤러
+ */
+@RestController
+@RequestMapping("/ingredients")
+@RequiredArgsConstructor
+public class IngredientController {
+
+    private final IngredientService ingredientService;
+
+    /**
+     * 전체 기준 재료 조회 API
+     * GET /ingredients
+     */
+    @GetMapping
+    public ResponseEntity<List<IngredientResponseDto>> getAllIngredients() {
+        List<IngredientResponseDto> list = ingredientService.getAllIngredients();
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/controller/UserIngredientController.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/controller/UserIngredientController.java
@@ -1,0 +1,51 @@
+package com.ohgiraffers.refrigegobackend.ingredients.controller;
+
+import com.ohgiraffers.refrigegobackend.ingredients.dto.UserIngredientRequestDto;
+import com.ohgiraffers.refrigegobackend.ingredients.dto.UserIngredientResponseDto;
+import com.ohgiraffers.refrigegobackend.ingredients.service.UserIngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 유저 보유 재료 관련 API 컨트롤러
+ */
+@RestController
+@RequestMapping("/user-ingredients")
+@RequiredArgsConstructor
+public class UserIngredientController {
+
+    private final UserIngredientService service;
+
+    /**
+     * 재료 등록 API
+     * POST /user-ingredients
+     */
+    @PostMapping
+    public ResponseEntity<String> addUserIngredient(@RequestBody UserIngredientRequestDto dto) {
+        service.addUserIngredient(dto);
+        return ResponseEntity.ok("재료가 성공적으로 등록되었습니다.");
+    }
+
+    /**
+     * 유저 냉장고 재료 전체 조회 API
+     * GET /user-ingredients?userId=uuid-be-001
+     */
+    @GetMapping
+    public ResponseEntity<List<UserIngredientResponseDto>> getUserIngredients(@RequestParam String userId) {
+        List<UserIngredientResponseDto> list = service.getUserIngredients(userId);
+        return ResponseEntity.ok(list);
+    }
+
+    /**
+     * 보유 재료 삭제 API
+     * DELETE /user-ingredients/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteUserIngredient(@PathVariable Long id) {
+        service.deleteUserIngredient(id);
+        return ResponseEntity.ok("재료가 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/domain/Ingredient.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/domain/Ingredient.java
@@ -1,0 +1,39 @@
+package com.ohgiraffers.refrigegobackend.ingredients.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 기준 재료(ingredients) 테이블 매핑용 엔티티 클래스
+ * - 이 클래스는 전체 공통 재료 목록을 저장한다 (예: 계란, 브로콜리 등)
+ * - 사용자 보유 재료가 아님 (user_ingredients 아님!)
+ */
+@Entity
+@Table(name = "ingredients")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Ingredient {
+
+    /**
+     * 재료 ID (기본 키, 자동 증가)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 재료명 (예: 계란, 양파, 고기 등)
+     * - null 불가
+     */
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * 재료 카테고리 (예: 채소, 고기, 유제품 등)
+     * - null 불가
+     */
+    @Column(nullable = false)
+    private String category;
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/domain/UserIngredient.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/domain/UserIngredient.java
@@ -1,0 +1,41 @@
+package com.ohgiraffers.refrigegobackend.ingredients.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+/**
+ * 유저가 냉장고에 등록한 재료 정보 엔티티
+ * - 기준 재료를 기반으로 유저 냉장고에 넣은 데이터
+ */
+@Entity
+@Table(name = "user_ingredients")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserIngredient {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;  // 고유 ID
+
+    @Column(nullable = false)
+    private String userId;  // 유저 ID
+
+    @Column(nullable = true)
+    private Long ingredientId;  // 기준 재료 ID
+
+    @Column(nullable = true)
+    private String customName;  // 유저가 직접 입력한 재료명
+
+    @Column(nullable = false)
+    private LocalDate purchaseDate;  // 구매일자
+
+    @Column(nullable = false)
+    private LocalDate expiryDate;    // 소비기한
+
+    @Column(nullable = false)
+    private boolean isFrozen;        // 냉동 보관 여부
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/dto/IngredientResponseDto.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/dto/IngredientResponseDto.java
@@ -1,0 +1,26 @@
+package com.ohgiraffers.refrigegobackend.ingredients.dto;
+
+import com.ohgiraffers.refrigegobackend.ingredients.domain.Ingredient;
+import lombok.Getter;
+
+/**
+ * 기준 재료 조회 응답 DTO
+ * - 클라이언트에게 재료 정보를 응답할 때 사용
+ */
+@Getter
+public class IngredientResponseDto {
+
+    private final Long id;        // 재료 ID
+    private final String name;    // 재료명
+    private final String category; // 카테고리
+
+    /**
+     * Entity → DTO 변환 생성자
+     * @param ingredient 기준 재료 엔티티
+     */
+    public IngredientResponseDto(Ingredient ingredient) {
+        this.id = ingredient.getId();
+        this.name = ingredient.getName();
+        this.category = ingredient.getCategory();
+    }
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/dto/UserIngredientRequestDto.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/dto/UserIngredientRequestDto.java
@@ -1,0 +1,21 @@
+package com.ohgiraffers.refrigegobackend.ingredients.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 유저가 보유 재료를 등록할 때 사용하는 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class UserIngredientRequestDto {
+
+    private String userId;         // 유저 ID
+    private Long ingredientId;    // 기준 재료 ID
+    private String customName;    // 직접 입력한 재료명
+    private LocalDate purchaseDate; // 구매일자
+    private LocalDate expiryDate;   // 소비기한
+    private boolean isFrozen;       // 냉동 보관 여부
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/dto/UserIngredientResponseDto.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/dto/UserIngredientResponseDto.java
@@ -1,0 +1,25 @@
+package com.ohgiraffers.refrigegobackend.ingredients.dto;
+
+import com.ohgiraffers.refrigegobackend.ingredients.domain.UserIngredient;
+import lombok.Getter;
+
+/**
+ * 유저 냉장고 보유 재료 조회 응답 DTO
+ */
+@Getter
+public class UserIngredientResponseDto {
+
+    private final Long id;             // user_ingredients 고유 ID
+    private final String userId;       // 유저 ID
+    private final Long ingredientId;   // 기준 재료 ID (nullable)
+    private final String name;         // 재료명 (기준재료 or 직접입력)
+    private final boolean isFrozen;    // 냉동 여부
+
+    public UserIngredientResponseDto(UserIngredient entity, String name) {
+        this.id = entity.getId();
+        this.userId = entity.getUserId();
+        this.ingredientId = entity.getIngredientId(); // 기준 재료 ID
+        this.name = name; // 기준 or custom 재료 이름
+        this.isFrozen = entity.isFrozen();
+    }
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/infrastructure/repository/IngredientRepository.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/infrastructure/repository/IngredientRepository.java
@@ -1,0 +1,18 @@
+package com.ohgiraffers.refrigegobackend.ingredients.infrastructure.repository;
+
+import com.ohgiraffers.refrigegobackend.ingredients.domain.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 기준 재료(ingredients) 테이블에 접근하는 JPA Repository
+ * - JpaRepository 덕분에 CRUD 메서드 자동 제공됨
+ * - ex) save(), findAll(), deleteById(), findById() 등
+ */
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+
+    /**
+     * 이름 중복 검사용 메서드 (선택사항)
+     * - 필요 없으면 안 써도 됨
+     */
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/infrastructure/repository/UserIngredientRepository.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/infrastructure/repository/UserIngredientRepository.java
@@ -1,0 +1,17 @@
+package com.ohgiraffers.refrigegobackend.ingredients.infrastructure.repository;
+
+import com.ohgiraffers.refrigegobackend.ingredients.domain.UserIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * 유저 보유 재료(user_ingredients) 테이블에 접근하는 JPA Repository
+ */
+public interface UserIngredientRepository extends JpaRepository<UserIngredient, Long> {
+
+    /**
+     * 특정 유저의 냉장고 재료 전부 조회
+     */
+    List<UserIngredient> findByUserId(String userId);
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/service/IngredientService.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/service/IngredientService.java
@@ -1,0 +1,29 @@
+package com.ohgiraffers.refrigegobackend.ingredients.service;
+
+import com.ohgiraffers.refrigegobackend.ingredients.domain.Ingredient;
+import com.ohgiraffers.refrigegobackend.ingredients.dto.IngredientResponseDto;
+import com.ohgiraffers.refrigegobackend.ingredients.infrastructure.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 기준 재료 관련 비즈니스 로직 처리
+ */
+@Service
+@RequiredArgsConstructor
+public class IngredientService {
+
+    private final IngredientRepository ingredientRepository;
+
+    /**
+     * 전체 기준 재료 조회
+     */
+    public List<IngredientResponseDto> getAllIngredients() {
+        return ingredientRepository.findAll().stream()
+                .map(IngredientResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/service/UserIngredientService.java
+++ b/src/main/java/com/ohgiraffers/refrigegobackend/ingredients/service/UserIngredientService.java
@@ -1,0 +1,67 @@
+package com.ohgiraffers.refrigegobackend.ingredients.service;
+
+import com.ohgiraffers.refrigegobackend.ingredients.domain.UserIngredient;
+import com.ohgiraffers.refrigegobackend.ingredients.dto.UserIngredientRequestDto;
+import com.ohgiraffers.refrigegobackend.ingredients.dto.UserIngredientResponseDto;
+import com.ohgiraffers.refrigegobackend.ingredients.infrastructure.repository.IngredientRepository;
+import com.ohgiraffers.refrigegobackend.ingredients.infrastructure.repository.UserIngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 유저 보유 재료 관련 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+public class UserIngredientService {
+
+    private final UserIngredientRepository repository;
+    private final IngredientRepository ingredientRepository;
+
+    /**
+     * 보유 재료 등록
+     */
+    public void addUserIngredient(UserIngredientRequestDto dto) {
+
+        // ingredientId 또는 customName 중 하나만 있어야 함
+        if ((dto.getIngredientId() == null && dto.getCustomName() == null) ||
+                (dto.getIngredientId() != null && dto.getCustomName() != null)) {
+            throw new IllegalArgumentException("ingredientId 또는 customName 중 하나만 입력해야 합니다.");
+        }
+
+        UserIngredient userIngredient = UserIngredient.builder()
+                .userId(dto.getUserId())
+                .ingredientId(dto.getIngredientId()) // 기준 재료일 경우만 값 존재
+                .customName(dto.getCustomName())     // 직접 입력일 경우만 값 존재
+                .purchaseDate(dto.getPurchaseDate())
+                .expiryDate(dto.getExpiryDate())
+                .isFrozen(dto.isFrozen())
+                .build();
+
+        repository.save(userIngredient);
+    }
+
+    /**
+     * 유저의 보유 재료 전체 조회
+     */
+    public List<UserIngredientResponseDto> getUserIngredients(String userId) {
+        return repository.findByUserId(userId).stream()
+                .map(ui -> {
+                    String name = (ui.getIngredientId() != null)
+                            ? ingredientRepository.findById(ui.getIngredientId()).orElseThrow().getName()
+                            : ui.getCustomName();
+                    return new UserIngredientResponseDto(ui, name);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 재료 삭제
+     */
+    public void deleteUserIngredient(Long id) {
+        repository.deleteById(id);
+    }
+}


### PR DESCRIPTION
### 주요 변경 사항

- 기준 재료 기반 + 사용자 직접 입력 기반 재료 등록 기능 구현
- 유저가 등록한 재료 전체 조회 기능 구현 (재료명 포함)
- 보유 재료 삭제 기능 추가
- 등록 및 삭제 시 응답 메시지 반환으로 UX 개선
- `ingredientId` 또는 `customName` 중 하나만 입력 가능하도록 유효성 검사 추가

### 테스트
- Postman을 통해 등록/조회/삭제 정상 작동 확인 완료
- DB 데이터 정상 반영 및 예외 없이 작동 확인